### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install and run tox
         run: |
@@ -37,18 +37,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.10"]
-        django: [31,40,main]
+        python: ["3.8", "3.10", "3.11"]
+        django: ["32", "41", "main"]
 
     env:
       TOXENV: py${{ matrix.python }}-django${{ matrix.django }}
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
   # python import sorting - will amend files
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.9.3
+    rev: v5.10.1
     hooks:
       - id: isort
 
   # python code formatting - will amend files
   - repo: https://github.com/ambv/black
-    rev: 21.12b0
+    rev: 22.10.0
     hooks:
       - id: black
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
+    rev: v3.1.0
     hooks:
       - id: pyupgrade
 
@@ -30,7 +30,7 @@ repos:
 
   # python static type checking
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910-1
+    rev: v0.982
     hooks:
       - id: mypy
         args:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## v0.2 [unreleased]
+
+* Add support for Python 3.11

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 yunojuno
+Copyright (c) 2022 yunojuno
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Django model custom field for storing a frozen snapshot of an object.
 
+### Version support
+
+The current version of the this app support **Python 3.8+** and **Django 3.2+**
+
 ## Principles
 
 * Behaves like a `ForeignKey` but the data is detached from the related object

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-frozen-field"
-version = "0.1.1"
+version = "0.2"
 description = "Django model field used to store snapshot of data."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -13,25 +13,25 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
+    "Framework :: Django :: 4.1",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 packages = [{ include = "frozen_field" }]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.8"
 django = "^3.2 | ^4.0"
 
 [tool.poetry.dev-dependencies]
-black = {version = "*", allow-prereleases = true}
+black = "*"
 coverage = "*"
 flake8 = "*"
 flake8-bandit = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = fmt, lint, mypy, checks, py{3.7,3.8,3.9,3.10}-django{31,32,40,main}
+envlist = fmt, lint, mypy, checks, py{3.8,3.9,3.10,3.11}-django{32,40,41,main}
 
 [testenv]
 deps =
@@ -9,9 +9,9 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
Add Python 3.11 to CI matrix, PyPI classifiers.

Bump version to 0.2